### PR TITLE
A fix for jq can't get pipe input properly while using searching func…

### DIFF
--- a/src/PKGBUILD
+++ b/src/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hunter Wittenborn <hunter@hunterwittenborn.com>
 
 pkgname=mpm
-pkgver=2.8.6
+pkgver=2.8.7
 pkgrel=1
 pkgdesc="Package manager for makedeb (git release)"
 depends=('makedeb' 'makedeb-db' 'jq' 'asp')

--- a/src/functions/search_pkg.sh
+++ b/src/functions/search_pkg.sh
@@ -3,7 +3,7 @@ search_pkg() {
 	search_query=$(echo "${PKG}" | sed 's/ //')
 
 	aur_search_url="${aur_url}rpc.php/rpc/?v=5&type=search&arg=${search_query}"
-	aur_search_results=$(curl -s -H "User-Agent: mpm/${mpm_version}" "${aur_search_url}" | jq)
+	aur_search_results=$(curl -s -H "User-Agent: mpm/${mpm_version}" "${aur_search_url}" | jq -r "")
 	arch_repository_search_results=$(curl -s -H "User-Agent: mpm/${mpm_version}" "${arch_repository_search_url}${search_query}")
 
 	if [[ $(echo ${aur_search_results} | jq -r '.resultcount') == "0" ]] && \


### PR DESCRIPTION
…tion
When i tried searching for alacritty and some fonts on AUR, i noticed that it's only showing jq usage guide text.

```
$ ./mpm.sh search mononoki
jq - commandline JSON processor [version 1.5-1-a5b5cbe]
Usage: jq [options] <jq filter> [file...]

	jq is a tool for processing JSON inputs, applying the
	given filter to its JSON text inputs and producing the
	filter's results as JSON on standard output.
	The simplest filter is ., which is the identity filter,
	copying jq's input to its output unmodified (except for
	formatting).
	For more advanced filters see the jq(1) manpage ("man jq")
	and/or https://stedolan.github.io/jq

	Some of the options include:
	 -c		compact instead of pretty-printed output;
	 -n		use `null` as the single input value;
	 -e		set the exit status code based on the output;
	 -s		read (slurp) all inputs into an array; apply filter to it;
	 -r		output raw strings, not JSON texts;
	 -R		read raw strings, not JSON texts;
	 -C		colorize JSON;
	 -M		monochrome (don't colorize JSON);
	 -S		sort keys of objects on output;
	 --tab	use tabs for indentation;
	 --arg a v	set variable $a to value <v>;
	 --argjson a v	set variable $a to JSON value <v>;
	 --slurpfile a f	set variable $a to an array of JSON texts read from <f>;
	See the manpage for more options.
(23) Failed writing body
```
After changing the line `... | jq` to `... | jq -r ""`, the results were showing correctly as seems:
```
$ ./mpm.sh search mononoki                                                                                                                                                  995ms

ttf-mononoki-git/r78.07f7e9b-1  AUR
  Description: Monospace font for programmers, successor of monoOne
  Votes: 21
  Maintainer: aperez
  Out Of Date: N/A
  Last Modified: 04-28-2020

nerd-fonts-mononoki/2.1.0-2  AUR
  Description: Patched font Mononoki from nerd-fonts library
  Votes: 3
  Maintainer: jef
  Out Of Date: N/A
  Last Modified: 12-15-2020

ttf-mononoki/1.3-1  AUR
  Description: Monospace font for programmers, successor of monoOne
  Votes: 19
  Maintainer: mrkline
  Out Of Date: N/A
  Last Modified: 02-01-2021
```